### PR TITLE
Tool and API to manipulate Docker images in registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2259,3 +2259,4 @@ A curated list of awesome Go frameworks, libraries and software.
 * [brianolson/go-openid](https://github.com/brianolson/go-openid) - OpenID implementation in Go
 * [IniZio/Go](https://github.com/IniZio/Go) - This is a lab for Go!
 * [6xiao/go](https://github.com/6xiao/go) - generic code
+* [lstags](https://github.com/ivanilves/lstags) - manipulates Docker images across different registries


### PR DESCRIPTION
lstags is a utility and an API to manipulate: 
* analyze
* synchronize
* aggregate
images across different Docker registries. 

#### I find it awesome because 
* it helps me to maintain my private registry and speed up my `docker run`
* besides it has awesome tests coverage and pretty nice code 

https://github.com/ivanilves/lstags