### PR TITLE
Add Fiber Web Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of awesome Go frameworks, libraries and software.
 * [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) - Production-Grade Container Scheduling and Management
 * [moby/moby](https://github.com/moby/moby) - Moby Project - a collaborative project for the container ecosystem to assemble container-based systems
 * [avelino/awesome-go](https://github.com/avelino/awesome-go) - A curated list of awesome Go frameworks, libraries and software
+* [gofiber/fiber](https://github.com/gofiber/fiber) - 🔌 Fiber is an Express.js styled HTTP web framework implementation running on 🚀 Fasthttp.
 * [gohugoio/hugo](https://github.com/gohugoio/hugo) - The world’s fastest framework for building websites.
 * [gin-gonic/gin](https://github.com/gin-gonic/gin) - Gin is a HTTP web framework written in Go (Golang). It features a Martini-like API with much better performance -- up to 40 times faster. If you need smashing performance, get yourself some Gin.
 * [astaxie/build-web-application-with-golang](https://github.com/astaxie/build-web-application-with-golang) - A golang ebook intro how to build a web with golang


### PR DESCRIPTION
**Description**

<img align="right" src="https://raw.githubusercontent.com/gofiber/fiber/master/docs/static/logo_320px_trans.png" width="150">

🔌 **[Fiber](https://github.com/gofiber/fiber)** is an [Express.js](https://expressjs.com/en/4x/api.html) styled HTTP web framework implementation running on 🚀 [Fasthttp](https://github.com/valyala/fasthttp), the **fastest** HTTP engine for Go. The package make use of **similar framework convention** as they are in Express.

People switching from [Node.js](https://nodejs.org/en/about/) to [Go](https://golang.org/doc/) often end up in a bad learning curve to start building their webapps, this project is meant to **ease** things up for **fast** development, but with **zero memory allocation** and **performance** in mind.


**Please provide package links to:**

- github.com repo: https://github.com/gofiber/fiber
- godoc.org: https://godoc.org/github.com/gofiber/fiber
- goreportcard.com: https://goreportcard.com/report/github.com/gofiber/fiber
- gocover.io: https://gocover.io/github.com/gofiber/fiber

_`gocover.io` seems to have a [time-out bug](https://github.com/vieux/gocover.io/issues/41). It complains about an error for `strconv.ParseFloat` which is not called anywhere in the source code.The test coverage is 0% when tested locally._

**Extra links:**
- API documentation: https://gofiber.github.io/fiber/
- Benchmarks: https://gofiber.github.io/fiber/#/benchmarks
