### PR TITLE
Add mani

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,3 +1040,4 @@ A curated list of awesome Go frameworks, libraries and software.
 * [colinmarc/hdfs](https://github.com/colinmarc/hdfs) - A native go client for HDFS
 * [steve0hh/midas](https://github.com/steve0hh/midas) - Go implementation of MIDAS: Microcluster-Based Detector of Anomalies in Edge Streams
 * [gookit/color](https://github.com/gookit/color) - A command-line color library with true color support, universal API methods and Windows support.
+* [alajmo/mani](https://github.com/alajmo/mani) - A CLI tool to help you manage multiple repositories


### PR DESCRIPTION
mani is a tool that helps you manage multiple repositories. It's helpful when you are working with microservices or multi-project system and libraries and want a central place for pulling all repositories and running commands over the different projects. You specify projects and commands in a yaml config and then run the commands over all or a subset of the projects.