### PR TITLE
Add golamify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,3 +1036,4 @@ A curated list of awesome Go frameworks, libraries and software.
 * [aelsabbahy/goss](https://github.com/aelsabbahy/goss) - Quick and Easy server testing/validation
 * [livekit/livekit](https://github.com/livekit/livekit) - Scalable, high-performance WebRTC SFU. SDKs in JavaScript, React, React Native, Flutter, Swift, Kotlin, Unity/C#, Go, Ruby and Node.
 * [monkeyWie/gopeed-core](https://github.com/monkeyWie/gopeed-core) - A fast download client,support HTTP&P2P.
+* [prasad89/golamify](https://github.com/prasad89/golamify) - A Go client library for seamless integration with the Ollama API.


### PR DESCRIPTION
### GoLamify Package

This PR adds the [GoLamify package](https://pkg.go.dev/github.com/prasad89/golamify), a Go library designed to simplify integration of Go projects with Ollama. 

The GoLamify package provides an easy and efficient way to connect Go applications with Ollama services, allowing for seamless interaction and enhanced functionality.