### PR TITLE
Added dec128

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,3 +1090,4 @@ A curated list of awesome Go frameworks, libraries and software.
 * [aelsabbahy/goss](https://github.com/aelsabbahy/goss) - Quick and Easy server testing/validation
 * [livekit/livekit](https://github.com/livekit/livekit) - Scalable, high-performance WebRTC SFU. SDKs in JavaScript, React, React Native, Flutter, Swift, Kotlin, Unity/C#, Go, Ruby and Node.
 * [monkeyWie/gopeed-core](https://github.com/monkeyWie/gopeed-core) - A fast download client,support HTTP&P2P.
+* [jokruger/dec128](https://github.com/jokruger/dec128) - High-performance 128-bit fixed-point decimal numbers in go.


### PR DESCRIPTION
Added dec128 - a high-performance 128-bit fixed-point decimal numbers in go.